### PR TITLE
Made context non-mandatory in retrieving entities.

### DIFF
--- a/src/main/java/uk/ac/ebi/spot/ontotools/curation/repository/EntityRepository.java
+++ b/src/main/java/uk/ac/ebi/spot/ontotools/curation/repository/EntityRepository.java
@@ -13,6 +13,8 @@ public interface EntityRepository extends MongoRepository<Entity, String> {
 
     Stream<Entity> readBySourceId(String sourceId);
 
+    List<Entity> findByProjectId(String projectId);
+
     Page<Entity> findByProjectId(String projectId, Pageable page);
 
     Page<Entity> findByProjectIdAndContext(String projectId, String context, Pageable page);

--- a/src/main/java/uk/ac/ebi/spot/ontotools/curation/repository/OntologyTermContextRepository.java
+++ b/src/main/java/uk/ac/ebi/spot/ontotools/curation/repository/OntologyTermContextRepository.java
@@ -14,6 +14,8 @@ public interface OntologyTermContextRepository extends MongoRepository<OntologyT
 
     Page<OntologyTermContext> findByHasMappingAndProjectIdAndContextAndStatus(boolean hasMapping, String projectId, String context, String status, Pageable pageable);
 
+    Page<OntologyTermContext> findByHasMappingAndProjectIdAndStatus(boolean hasMapping, String projectId, String status, Pageable pageable);
+
     List<OntologyTermContext> findByHasMappingAndProjectIdAndContextAndStatus(boolean hasMapping, String projectId, String context, String status);
 
     Stream<OntologyTermContext> readByHasMappingAndProjectIdAndContextAndStatus(boolean hasMapping, String projectId, String context, String status);

--- a/src/main/java/uk/ac/ebi/spot/ontotools/curation/rest/controller/OntologyTermController.java
+++ b/src/main/java/uk/ac/ebi/spot/ontotools/curation/rest/controller/OntologyTermController.java
@@ -79,7 +79,7 @@ public class OntologyTermController {
     @ResponseStatus(HttpStatus.OK)
     public RestResponsePage<ExtendedOntologyTermDto> getOntologyTerms(@PathVariable String projectId,
                                                                       @RequestParam(value = CurationConstants.PARAM_STATUS) String status,
-                                                                      @RequestParam(value = CurationConstants.PARAM_CONTEXT) String context,
+                                                                      @RequestParam(value = CurationConstants.PARAM_CONTEXT, required = false) String context,
                                                                       @PageableDefault(size = 20) Pageable pageable,
                                                                       HttpServletRequest request) {
         User user = jwtService.extractUser(HeadersUtil.extractJWT(request));

--- a/src/main/java/uk/ac/ebi/spot/ontotools/curation/service/impl/OntologyTermServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/spot/ontotools/curation/service/impl/OntologyTermServiceImpl.java
@@ -206,7 +206,10 @@ public class OntologyTermServiceImpl implements OntologyTermService {
     @Override
     public Page<OntologyTermContext> retrieveMappedTermsByStatus(String projectId, String context, String status, Pageable pageable) {
         log.info("Retrieving terms by status: {} | {} | {}", projectId, context, status);
-        Page<OntologyTermContext> ontologyTermContextPage = ontologyTermContextRepository.findByHasMappingAndProjectIdAndContextAndStatus(true, projectId, context, status, pageable);
+        Page<OntologyTermContext> ontologyTermContextPage =
+                context == null ?
+                        ontologyTermContextRepository.findByHasMappingAndProjectIdAndStatus(true, projectId, status, pageable) :
+                        ontologyTermContextRepository.findByHasMappingAndProjectIdAndContextAndStatus(true, projectId, context, status, pageable);
         return ontologyTermContextPage;
     }
 

--- a/src/main/java/uk/ac/ebi/spot/ontotools/curation/service/impl/OntologyTermUtilServiceImpl.java
+++ b/src/main/java/uk/ac/ebi/spot/ontotools/curation/service/impl/OntologyTermUtilServiceImpl.java
@@ -80,7 +80,8 @@ public class OntologyTermUtilServiceImpl implements OntologyTermUtilService {
 
     @Override
     public Map<OntologyTerm, Map<String, String>> retrieveEntityData(List<String> ontoTermIds, List<OntologyTermContext> ontologyTermContexts, String projectId, String context) {
-        List<Entity> entities = entityRepository.findByProjectIdAndContext(projectId, context);
+        List<Entity> entities = context == null ? entityRepository.findByProjectId(projectId) :
+                entityRepository.findByProjectIdAndContext(projectId, context);
         Map<String, String> entityMap = new LinkedHashMap<>();
         for (Entity entity : entities) {
             entityMap.put(entity.getId(), entity.getName());


### PR DESCRIPTION
 - endpoint changed: `GET /v1/projects/{projectId}/ontology-terms?status=<STATUS>&context=<CONTEXT>`